### PR TITLE
Fix default target dir for generated .erl files.

### DIFF
--- a/src/rebar3_gpb_compiler.erl
+++ b/src/rebar3_gpb_compiler.erl
@@ -23,7 +23,7 @@ compile(AppInfo) ->
                                                    ?DEFAULT_PROTO_DIR)]),
     TargetErlDir = filename:join([AppOutDir,
                                   proplists:get_value(o_erl, GpbOpts0,
-                                                      ?DEFAULT_OUT_HRL_DIR)]),
+                                                      ?DEFAULT_OUT_ERL_DIR)]),
     TargetHrlDir = filename:join([AppOutDir,
                                   proplists:get_value(o_hrl, GpbOpts0,
                                                       ?DEFAULT_OUT_HRL_DIR)]),


### PR DESCRIPTION
Correcting a simple typo from HRL to ERL.
